### PR TITLE
Add setup script and Codex configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,12 @@ SmartTube is developed single-handedly; there is no larger team or company behin
 
 ## Build
     
-**NOTE: OpenJDK 14 or older (!) is required. Newer JDK could cause app crash!**  
+**NOTE: OpenJDK 14 or older (!) is required. Newer JDK could cause app crash!**
+
+Ensure the `JAVA_HOME` environment variable points to your JDK installation so
+Gradle can locate the correct Java runtime.
+If you're using a fresh environment, run the provided `setup.sh` script to
+install the system packages required for building.
 To build and install debug version, run these commands:
 
 ```

--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,2 @@
+setup:
+  - ./setup.sh

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 android.enableJetifier = true
-org.gradle.java.home=C:/Program Files/Eclipse Adoptium/jdk-11.0.27.6-hotspot
+# Use JAVA_HOME from the environment if defined.
+org.gradle.java.home=${JAVA_HOME}
 
 
 android.useAndroidX = true

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# setup.sh - Install dependencies required for building SmartTube
+set -e
+
+# Update package lists
+sudo apt-get update
+
+# Install OpenJDK 11 and other tools
+sudo apt-get install -y openjdk-11-jdk git curl wget unzip
+
+# Additional dependencies can be installed here
+


### PR DESCRIPTION
## Summary
- add `setup.sh` for installing dependencies
- reference `setup.sh` in the build docs
- configure environment with `codex.yaml`

## Testing
- `bash ./gradlew tasks --all` *(fails: Unable to tunnel through proxy to download gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_685a2baa5de4832987695e8d1df30e1e